### PR TITLE
Add option to ignore no-cache headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ options {Object}:
 * `cacheKeyArgs`: `{String}` Default cache key to be used internally by the library.
 * `cacheKeyPrefix`: `{String}` Cache key prefix for storing.
 * `minimumSize`: `{Number}` Minimum http body size needed to cache the response.
+* `ignoreNoCache`: `{Boolean}` Flag for ignoring 'Cache-Control: no-cache' headers.
 * `debug`: `{Boolean}` Flag showing whether to debug the middleware or not.
 * `logging`: `{Function}` External logging function to be used for debugging.
 

--- a/index.js
+++ b/index.js
@@ -201,8 +201,8 @@ class Cache {
           else continue
         }
 
-        // check if no-cache is provided
-        if (this.request.header['cache-control'] === 'no-cache') {
+        // check if no-cache is provided (if not overridden)
+        if (that.options.ignoreNoCache !== true && this.request.header['cache-control'] === 'no-cache') {
           return yield next
         }
 


### PR DESCRIPTION
This will add the possibility to ignore `Cache-Control: no-cache` headers, if desired.
